### PR TITLE
feat: AOP를 활용한 로그인 인증 기능 구현

### DIFF
--- a/board-server/build.gradle
+++ b/board-server/build.gradle
@@ -13,6 +13,12 @@ java {
 	}
 }
 
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+}
+
 repositories {
 	mavenCentral()
 }
@@ -24,11 +30,15 @@ dependencies {
 	//Spring Boot Web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	//Spring Boot Mybatis
-	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.2'
+	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
+	//Spring AOP
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	//Mysql
-	implementation 'mysql:mysql-connector-java:8.0.33'
+	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	compileOnly group: 'javax.servlet', name: 'javax.servlet-api', version: '3.0.1'
 }
 
 tasks.named('test') {

--- a/board-server/src/main/java/com/fastcampus/board_server/aop/LoginCheck.java
+++ b/board-server/src/main/java/com/fastcampus/board_server/aop/LoginCheck.java
@@ -1,0 +1,16 @@
+package com.fastcampus.board_server.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface LoginCheck {
+    public static enum UserType {
+        USER, ADMIN
+    }
+
+    UserType type();
+}

--- a/board-server/src/main/java/com/fastcampus/board_server/aop/LoginCheckAspect.java
+++ b/board-server/src/main/java/com/fastcampus/board_server/aop/LoginCheckAspect.java
@@ -1,0 +1,57 @@
+package com.fastcampus.board_server.aop;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import com.fastcampus.board_server.utils.SessionUtil;
+
+import jakarta.servlet.http.HttpSession;
+import lombok.extern.log4j.Log4j2;
+
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+@Component
+@Aspect
+@Order(Ordered.LOWEST_PRECEDENCE)
+@Log4j2
+public class LoginCheckAspect {
+    @Around("@annotation(com.fastcampus.board_server.aop.LoginCheck) && @annotation(currentLoginCheckAnnotation)")
+    public Object adminLoginCheck(ProceedingJoinPoint proceedingJoinPoint, LoginCheck currentLoginCheckAnnotation) throws Throwable {
+        HttpSession session = (HttpSession) ((ServletRequestAttributes) (RequestContextHolder
+                .currentRequestAttributes())).getRequest().getSession();
+        String id = null;
+        int idIndex = 0;
+
+        String userType = currentLoginCheckAnnotation.type().toString();
+        switch (userType) {
+            case "ADMIN": {
+                id = SessionUtil.getLoginAdminId(session);
+                break;
+            }
+            case "USER": {
+                id = SessionUtil.getLoginMemberId(session);
+                break;
+            }
+        }
+        if (id == null) {
+            log.debug(proceedingJoinPoint.toString() + "accountName :" + id);
+            throw new HttpStatusCodeException(UNAUTHORIZED, "로그인한 id값을 확인해주세요.") {
+            };
+        }
+
+        Object[] modifiedArgs = proceedingJoinPoint.getArgs();
+
+        if (proceedingJoinPoint.getArgs() != null)
+            modifiedArgs[idIndex] = id;
+
+        return proceedingJoinPoint.proceed(modifiedArgs);
+    }
+
+}

--- a/board-server/src/main/java/com/fastcampus/board_server/config/MysqlConfig.java
+++ b/board-server/src/main/java/com/fastcampus/board_server/config/MysqlConfig.java
@@ -5,6 +5,7 @@ import javax.sql.DataSource;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
@@ -13,6 +14,7 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 @MapperScan(basePackages = "com.fastcampus.board_server.mapper")
 public class MysqlConfig {
     
+    @Bean
     public SqlSessionFactory sqlSessionFactory(DataSource dataSource) throws Exception {
         final SqlSessionFactoryBean sessionFactory = new SqlSessionFactoryBean();
         sessionFactory.setDataSource(dataSource);

--- a/board-server/src/main/java/com/fastcampus/board_server/controller/UserController.java
+++ b/board-server/src/main/java/com/fastcampus/board_server/controller/UserController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.fastcampus.board_server.aop.LoginCheck;
 import com.fastcampus.board_server.dto.UserDto;
 import com.fastcampus.board_server.dto.request.UserDeleteId;
 import com.fastcampus.board_server.dto.request.UserLoginRequest;
@@ -89,11 +90,12 @@ public class UserController {
     }
 
     @PatchMapping("password")
-    public ResponseEntity<LoginResponse> updateUserPassword(
+    @LoginCheck(type = LoginCheck.UserType.USER)
+    public ResponseEntity<LoginResponse> updateUserPassword(String accountId,
             @RequestBody UserUpdatePasswordRequest userUpdatePasswordRequest,
             HttpSession session) {
         ResponseEntity<LoginResponse> responseEntity = null;
-        String Id = SessionUtil.getLoginMemberId(session);
+        String Id = accountId;
         String beforePassword = userUpdatePasswordRequest.beforePassword();
         String afterPassword = userUpdatePasswordRequest.afterPassword();
 

--- a/board-server/src/main/resources/application.yml
+++ b/board-server/src/main/resources/application.yml
@@ -6,5 +6,6 @@ spring:
         driver-class-name: com.mysql.cj.jdbc.Driver
 
 mybatis:
-    mapper-locations: classpath:com/fastcampus/board_server/mapper/*.xml
+    config-location: classpath:mybatis-config.xml
+    mapper-locations: classpath:mappers/*.xml
     


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes: #3
## ✅ 주요 작업 내용

- [x] AOP 기반 로그인 인증 시스템 구현
- [x] @LoginCheck 커스텀 어노테이션 추가 및 타입 기반 권한 구분(USER/ADMIN)
- [x] LoginCheckAspect 클래스 구현으로 세션 검증 로직 중앙화
- [x] 비밀번호 변경 API에 어노테이션 적용 및 컨트롤러에서 세션 처리 코드 제거
- [x] 의존성 및 빌드 설정 개선
- [x] MySQL 커넥터 최신 버전으로 업데이트
- [x] MyBatis 설정 수정
- [x] @Bean 어노테이션으로 SqlSessionFactory 명시적 등록
- [x] application.yml에서 매퍼 경로 수정 (classpath:mappers/*.xml)
- [x] mybatis-config.xml 설정 경로 추가

## 🤔 작업 배경 및 고민 과정
본 내용은 fastcampus 강의 내용입니다.

## ✨ 셀프 리뷰 체크리스트
x

## 🖼️ 스크린샷 (필요시)

<img src="파일 주소" width="50%" height="50%">
<br/>

## 💡 추가 전달 사항
