### PR TITLE
feat: 게시글 및 카테고리 관리 REST API 구현

### DIFF
--- a/board-server/src/main/java/com/fastcampus/board_server/controller/CategoryController.java
+++ b/board-server/src/main/java/com/fastcampus/board_server/controller/CategoryController.java
@@ -1,0 +1,65 @@
+package com.fastcampus.board_server.controller;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fastcampus.board_server.aop.LoginCheck;
+import com.fastcampus.board_server.dto.CategoryDTO;
+import com.fastcampus.board_server.service.CategoryService;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+@RestController
+@RequestMapping("/categories")
+@Log4j2
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @PostMapping
+    @ResponseStatus(CREATED)
+    @LoginCheck(type = LoginCheck.UserType.ADMIN)
+    public void registerCategory(String accountId, @RequestBody CategoryDTO categoryDTO) {
+        categoryService.register(accountId, categoryDTO);
+    }
+
+    @PatchMapping("{categoryId}")
+    @LoginCheck(type = LoginCheck.UserType.ADMIN)
+    public void updateCategories(String accountId,
+        @PathVariable(name = "categoryId") int categoryId,
+        @RequestBody CategoryRequest categoryRequest
+    ) {
+        CategoryDTO categoryDTO = new CategoryDTO(categoryId, categoryRequest.getName(), CategoryDTO.SortStatus.NEWEST, 10, 1);
+        categoryService.update(categoryDTO);
+    }
+
+    @DeleteMapping("{categoryId}")
+    @LoginCheck(type = LoginCheck.UserType.ADMIN)
+    public void updateCategories(String accountId,
+        @PathVariable(name = "categoryId") int categoryId
+    ) {
+        categoryService.delete(categoryId);
+    }
+
+    // -------------- request 객체 --------------
+
+    @Setter
+    @Getter
+    private static class CategoryRequest {
+        private int id;
+        private String name;
+    }
+
+}

--- a/board-server/src/main/java/com/fastcampus/board_server/controller/PostController.java
+++ b/board-server/src/main/java/com/fastcampus/board_server/controller/PostController.java
@@ -1,0 +1,126 @@
+package com.fastcampus.board_server.controller;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fastcampus.board_server.aop.LoginCheck;
+import com.fastcampus.board_server.dto.PostDTO;
+import com.fastcampus.board_server.dto.UserDto;
+import com.fastcampus.board_server.dto.response.CommonResponse;
+import com.fastcampus.board_server.service.PostService;
+import com.fastcampus.board_server.service.UserService;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
+
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
+
+import java.util.Date;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+
+@RestController
+@RequestMapping("/posts")
+@Log4j2
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+    private final UserService userService;
+
+    @PostMapping
+    @ResponseStatus(CREATED)
+    @LoginCheck(type = LoginCheck.UserType.USER)
+    public ResponseEntity<CommonResponse<PostDTO>> registerPost(
+        String accountId, @RequestBody PostDTO postDTO
+    ) {
+        postService.register(accountId, postDTO);
+        CommonResponse<PostDTO> commonResponse = new CommonResponse<>(OK, "SUCCESS", "registerPost", postDTO);
+        return ResponseEntity.ok(commonResponse);
+    }
+
+    @GetMapping("my-posts")
+    @LoginCheck(type = LoginCheck.UserType.USER)
+    public ResponseEntity<CommonResponse<List<PostDTO>>> myPostInfo(String accountId) {
+        UserDto memberInfo = userService.getUserProfile(accountId);
+        List<PostDTO> postDTOList = postService.getMyProducts(memberInfo.getId());
+        CommonResponse<List<PostDTO>> commonResponse = new CommonResponse<>(OK, "SUCCESS", "myPostInfo", postDTOList);
+        return ResponseEntity.ok(commonResponse);
+    }
+
+    @PatchMapping("{postId}")
+    @LoginCheck(type = LoginCheck.UserType.USER)
+    public ResponseEntity<CommonResponse<PostRequest>> updatePosts(String accountId,
+        @PathVariable(name = "postId") int postId,
+        @RequestBody PostRequest postRequest
+    ) {
+        UserDto memberInfo = userService.getUserProfile(accountId);
+        PostDTO postDTO = PostDTO.builder()
+                .id(postId)
+                .name(postRequest.getName())
+                .contents(postRequest.getContents())
+                .views(postRequest.getViews())
+                .categoryId(postRequest.getCategoryId())
+                .userId(memberInfo.getId())
+                .fileId(postRequest.getFileId())
+                .updateTime(new Date())
+                .build();
+        postService.updateProducts(postDTO);
+        CommonResponse<PostRequest> commonResponse = new CommonResponse<>(OK, "SUCCESS", "updatePosts", postRequest);
+        return ResponseEntity.ok(commonResponse);
+    }
+
+    @DeleteMapping("{postId}")
+    @LoginCheck(type = LoginCheck.UserType.USER)
+    public ResponseEntity<CommonResponse<PostDeleteRequest>> deleteposts(
+        String accountId,
+        @PathVariable(name = "postId") int postId,
+        @RequestBody PostDeleteRequest postDeleteRequest
+    ) {
+        UserDto memberInfo = userService.getUserProfile(accountId);
+        postService.deleteProduct(memberInfo.getId(), postId);
+        CommonResponse<PostDeleteRequest> commonResponse = new CommonResponse<>(OK, "SUCCESS", "deleteposts", postDeleteRequest);
+        return ResponseEntity.ok(commonResponse);
+    }
+
+    // -------------- response 객체 --------------
+
+    @Getter
+    @AllArgsConstructor
+    private static class PostResponse {
+        private List<PostDTO> postDTO;
+    }
+
+    // -------------- request 객체 --------------
+
+    @Setter
+    @Getter
+    private static class PostRequest {
+        private String name;
+        private String contents;
+        private int views;
+        private int categoryId;
+        private int userId;
+        private int fileId;
+        private Date updateTime;
+    }
+
+    @Setter
+    @Getter
+    private static class PostDeleteRequest {
+        private int id;
+        private int accountId;
+    }
+}

--- a/board-server/src/main/java/com/fastcampus/board_server/dto/CategoryDTO.java
+++ b/board-server/src/main/java/com/fastcampus/board_server/dto/CategoryDTO.java
@@ -1,0 +1,26 @@
+package com.fastcampus.board_server.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Builder
+@ToString
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CategoryDTO {
+    public enum SortStatus {
+        CATEGORIES, NEWEST, OLDEST, HIGHPRICE, LOWPRICE, GRADE
+    }
+
+    private int id;
+    private String name;
+    private SortStatus sortStatus;
+    private int searchCount;
+    private int pagingStartOffset;
+}

--- a/board-server/src/main/java/com/fastcampus/board_server/dto/PostDTO.java
+++ b/board-server/src/main/java/com/fastcampus/board_server/dto/PostDTO.java
@@ -1,0 +1,29 @@
+package com.fastcampus.board_server.dto;
+
+import java.util.Date;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Builder
+@ToString
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostDTO {
+    private int id;
+    private String name;
+    private int isAdmin;
+    private String contents;
+    private Date createTime;
+    private int views;
+    private int categoryId;
+    private int userId;
+    private int fileId;
+    private Date updateTime;
+}

--- a/board-server/src/main/java/com/fastcampus/board_server/dto/response/CommonResponse.java
+++ b/board-server/src/main/java/com/fastcampus/board_server/dto/response/CommonResponse.java
@@ -1,0 +1,18 @@
+package com.fastcampus.board_server.dto.response;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommonResponse<T> {
+
+    private HttpStatus status;
+    private String code;
+    private String message;
+    private T requestBody;
+}

--- a/board-server/src/main/java/com/fastcampus/board_server/mapper/CategoryMapper.java
+++ b/board-server/src/main/java/com/fastcampus/board_server/mapper/CategoryMapper.java
@@ -1,0 +1,14 @@
+package com.fastcampus.board_server.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.fastcampus.board_server.dto.CategoryDTO;
+
+@Mapper
+public interface CategoryMapper {
+    public int register(CategoryDTO productDTO);
+
+    public void updateCategory(CategoryDTO categoryDTO);
+
+    public void deleteCategory(int categoryId);
+}

--- a/board-server/src/main/java/com/fastcampus/board_server/mapper/PostMapper.java
+++ b/board-server/src/main/java/com/fastcampus/board_server/mapper/PostMapper.java
@@ -1,0 +1,18 @@
+package com.fastcampus.board_server.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.fastcampus.board_server.dto.PostDTO;
+
+@Mapper
+public interface PostMapper {
+    public int register(PostDTO postDTO);
+
+    public List<PostDTO> selectMyProducts(int accountId);
+
+    public void updateProducts(PostDTO postDTO);
+
+    public void deleteProduct(int productId);
+}

--- a/board-server/src/main/java/com/fastcampus/board_server/service/CategoryService.java
+++ b/board-server/src/main/java/com/fastcampus/board_server/service/CategoryService.java
@@ -1,0 +1,12 @@
+package com.fastcampus.board_server.service;
+
+import com.fastcampus.board_server.dto.CategoryDTO;
+
+public interface CategoryService {
+
+    void register(String accountId, CategoryDTO categoryDTO);
+
+    void update(CategoryDTO categoryDTO);
+
+    void delete(int categoryId);
+}

--- a/board-server/src/main/java/com/fastcampus/board_server/service/PostService.java
+++ b/board-server/src/main/java/com/fastcampus/board_server/service/PostService.java
@@ -1,0 +1,16 @@
+package com.fastcampus.board_server.service;
+
+import java.util.List;
+
+import com.fastcampus.board_server.dto.PostDTO;
+
+public interface PostService {
+
+    void register(String id, PostDTO postDTO);
+
+    List<PostDTO> getMyProducts(int accountId);
+
+    void updateProducts(PostDTO postDTO);
+
+    void deleteProduct(int userId, int productId);
+}

--- a/board-server/src/main/java/com/fastcampus/board_server/service/impl/CategoryServiceImpl.java
+++ b/board-server/src/main/java/com/fastcampus/board_server/service/impl/CategoryServiceImpl.java
@@ -1,0 +1,50 @@
+package com.fastcampus.board_server.service.impl;
+
+import org.springframework.stereotype.Service;
+
+import com.fastcampus.board_server.dto.CategoryDTO;
+import com.fastcampus.board_server.mapper.CategoryMapper;
+import com.fastcampus.board_server.service.CategoryService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class CategoryServiceImpl implements CategoryService {
+
+    private final CategoryMapper categoryMapper;
+    
+    
+    @Override
+    public void register(String accountId, CategoryDTO categoryDTO) {
+        if (accountId != null) {
+            categoryMapper.register(categoryDTO);
+        } else {
+            log.error("register ERROR! {}", categoryDTO);
+            throw new RuntimeException("register ERROR! 상품 카테고리 등록 메서드를 확인해주세요\n" + "Params : " + categoryDTO);
+        }
+
+    }
+
+    @Override
+    public void update(CategoryDTO categoryDTO) {
+        if (categoryDTO != null) {
+            categoryMapper.updateCategory(categoryDTO);
+        } else {
+            log.error("update ERROR! {}", categoryDTO);
+            throw new RuntimeException("update ERROR! 물품 카테고리 변경 메서드를 확인해주세요\n" + "Params : " + categoryDTO);
+        }
+    }
+
+    @Override
+    public void delete(int categoryId) {
+        if (categoryId != 0) {
+            categoryMapper.deleteCategory(categoryId);
+        } else {
+            log.error("deleteCategory ERROR! {}", categoryId);
+            throw new RuntimeException("deleteCategory ERROR! 물품 카테고리 삭제 메서드를 확인해주세요\n" + "Params : " + categoryId);
+        }
+    }
+}

--- a/board-server/src/main/java/com/fastcampus/board_server/service/impl/PostServiceImpl.java
+++ b/board-server/src/main/java/com/fastcampus/board_server/service/impl/PostServiceImpl.java
@@ -1,0 +1,66 @@
+package com.fastcampus.board_server.service.impl;
+
+import java.util.Date;
+import java.util.List;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.stereotype.Service;
+
+import com.fastcampus.board_server.dto.PostDTO;
+import com.fastcampus.board_server.dto.UserDto;
+import com.fastcampus.board_server.mapper.PostMapper;
+import com.fastcampus.board_server.mapper.UserMapper;
+import com.fastcampus.board_server.service.PostService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class PostServiceImpl implements PostService {
+
+    private final PostMapper postMapper;
+    private final UserMapper userMapper;
+    
+    @CacheEvict(value = "getProducts", allEntries = true)
+    @Override
+    public void register(String id, PostDTO postDTO) {
+        UserDto memberInfo = userMapper.getUserProfile(id);
+        postDTO.setUserId(memberInfo.getId());
+        postDTO.setCreateTime(new Date());
+
+        if (memberInfo == null) {
+            log.error("register ERROR! {}", postDTO);
+            throw new RuntimeException("register ERROR! 상품 등록 메서드를 확인해주세요\n" + "Params : " + postDTO);
+        }
+
+        postMapper.register(postDTO);
+    }
+
+    @Override
+    public List<PostDTO> getMyProducts(int accountId) {
+        List<PostDTO> postDTOList = postMapper.selectMyProducts(accountId);
+        return postDTOList;
+    }
+
+    @Override
+    public void updateProducts(PostDTO postDTO) {
+        if (postDTO != null && postDTO.getId() != 0 && postDTO.getUserId() != 0) {
+            postMapper.updateProducts(postDTO);
+        } else {
+            log.error("updateProducts ERROR! {}", postDTO);
+            throw new RuntimeException("updateProducts ERROR! 물품 변경 메서드를 확인해주세요\n" + "Params : " + postDTO);
+        }
+    }
+
+    @Override
+    public void deleteProduct(int userId, int productId) {
+        if (userId != 0 && productId != 0) {
+            postMapper.deleteProduct(productId);
+        } else {
+            log.error("deleteProudct ERROR! {}", productId);
+            throw new RuntimeException("updateProducts ERROR! 물품 삭제 메서드를 확인해주세요\n" + "Params : " + productId);
+        }
+    }
+}

--- a/board-server/src/main/java/com/fastcampus/board_server/service/impl/UserServiceImpl.java
+++ b/board-server/src/main/java/com/fastcampus/board_server/service/impl/UserServiceImpl.java
@@ -61,7 +61,7 @@ public class UserServiceImpl implements UserService {
 
         if (memberInfo != null) {
             memberInfo.setPassword(SHA256Util.encryptSHA256(newPassword));
-            int insertCount = userMapper.updatePassword(memberInfo);
+            userMapper.updatePassword(memberInfo);
         } else {
             log.error("updatePasswrod ERROR! {}", memberInfo);
             throw new IllegalArgumentException(

--- a/board-server/src/main/resources/mappers/categoryMapper.xml
+++ b/board-server/src/main/resources/mappers/categoryMapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.fastcampus.board_server.mapper.CategoryMapper">
+
+    <insert id="register" parameterType="com.fastcampus.board_server.dto.CategoryDTO">
+        INSERT INTO category (id, name)
+        VALUES (#{id}, #{name})
+    </insert>
+
+    <update id="updateCategory" parameterType="com.fastcampus.board_server.dto.CategoryDTO">
+        UPDATE category
+        SET name = #{name}
+        WHERE id = #{id}
+    </update>
+
+    <delete id="deleteCategory">
+        DELETE FROM category
+        WHERE id = #{id}
+    </delete>
+
+</mapper>

--- a/board-server/src/main/resources/mappers/postMapper.xml
+++ b/board-server/src/main/resources/mappers/postMapper.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.fastcampus.board_server.mapper.PostMapper">
+
+    <insert id="register" parameterType="com.fastcampus.board_server.dto.PostDTO">
+        INSERT INTO post (name, isAdmin, contents, createTime, views, categoryId, userId, fileId, updateTime )
+        VALUES (#{name}, #{isAdmin}, #{contents}, #{createTime}, #{views}, #{categoryId}, #{userId}, #{fileId}, #{updateTime})
+    </insert>
+
+    <select id="selectMyProducts" resultType="com.fastcampus.board_server.dto.PostDTO">
+        SELECT id,
+               name,
+               isAdmin,
+               contents,
+               createTime,
+               views,
+               categoryId,
+               userId,
+               fileId,
+               updateTime
+        FROM post
+        WHERE userId = #{userId}
+    </select>
+
+    <update id="updateProducts" parameterType="com.fastcampus.board_server.dto.PostDTO">
+        UPDATE post
+        SET name = #{name},
+            contents = #{contents},
+            views = #{views},
+            categoryId = #{categoryId},
+            userId = #{userId},
+            fileId = #{fileId},
+            updateTime = #{updateTime}
+        WHERE id = #{id}
+    </update>
+
+    <delete id="deleteProduct" >
+        DELETE FROM post
+        WHERE id = #{productId}
+    </delete>
+
+</mapper>

--- a/board-server/src/main/resources/mappers/userMapper.xml
+++ b/board-server/src/main/resources/mappers/userMapper.xml
@@ -4,7 +4,7 @@
 <mapper namespace="com.fastcampus.board_server.mapper.UserMapper">
 
     <select id="getUserProfile" resultType="com.fastcampus.board_server.dto.UserDto">
-        SELECT userId, userId, password, nickName, createTime, isWithDraw, status
+        SELECT id, userId, userId, password, nickName, createTime, isWithDraw, status
         FROM user
         WHERE userId = #{userId}
     </select>


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes: #6
## ✅ 주요 작업 내용

- [] 게시글 CRUD 기능 구현 (PostController, PostService, PostMapper)
- [] 카테고리 관리 기능 구현 (CategoryController, CategoryService, CategoryMapper)
- [] 공통 응답 객체(CommonResponse) 추가로 일관된 API 응답 형식 제공
- [] UserServiceImpl에서 미사용 변수 제거
- [] userMapper.xml의 getUserProfile 쿼리에 id 필드 추가

## 🤔 작업 배경 및 고민 과정
본 내용은 페스트 캠퍼스 강의 내용입니다.

## ✨ 셀프 리뷰 체크리스트
x

## 🖼️ 스크린샷 (필요시)

<img src="파일 주소" width="50%" height="50%">
<br/>

## 💡 추가 전달 사항
